### PR TITLE
Fix zodiac enum typos

### DIFF
--- a/src/shared/types/astro-zodiac.ts
+++ b/src/shared/types/astro-zodiac.ts
@@ -7,7 +7,7 @@ export enum ASTRO_ZODIAC {
   VIRGO = 'Virgo',
   LIBRA = 'Libra',
   SCORPIO = 'Scorpio',
-  SAGITTARIUS = 'Saggitarius',
+  SAGITTARIUS = 'Sagittarius',
   CAPRICORN = 'Capricorn',
   AQUARIUS = 'Aquarius',
   PISCES = 'Pisces',
@@ -21,7 +21,7 @@ export enum ASTRO_ZODIAC_ELEMENT {
 }
 
 export enum ASTRO_ZODIAC_MODALITY {
-  CARDINAL = 'сardinanal',
+  CARDINAL = 'cardinal',
   FIXED = 'fixed',
   MUTABLE = 'mutable',
 }


### PR DESCRIPTION
## Summary
- correct spelling of Sagittarius
- fix CARDINAL modality typo

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842b1a9f9ac832d8d9a0a931f774eb6